### PR TITLE
relative path for owl file

### DIFF
--- a/PMK/interfaceprologcpp/prolog/pmk.pl
+++ b/PMK/interfaceprologcpp/prolog/pmk.pl
@@ -19,7 +19,7 @@
 
 %Pasring the pmk ontology.
 
-:- rdf_load('/home/diab/pmk_ws/src/PMK/PMK/interfaceprologcpp/owl/know.owl').
+:- rdf_load('../owl/know.owl').
 
 :- rdf_db:rdf_register_ns(sir_pmk, 'http://www.co-ode.org/ontologies/ont.owl#', [keep(true)]).
 


### PR DESCRIPTION
To avoid the need for modifying files to run the example, it is possible to use a relative path for the ontology file to load.